### PR TITLE
Add sitemap cache

### DIFF
--- a/src/Helper/Locator.php
+++ b/src/Helper/Locator.php
@@ -27,14 +27,19 @@ final class Locator
 
     public function locateNamespaceControllers(string $namespace): iterable
     {
+        $matches = [];
         foreach ($this->locator->findClasses(Controller::class) as $match) {
             /** @var Controller $controller */
             $controller = $match->getAnnotation();
             if ($controller->namespace !== $namespace) {
                 continue;
             }
+            $matches[$match->getClass()->getFileName()] = $match;
+        }
 
-            yield $match->getClass() => $controller;
+        ksort($matches);
+        foreach ($matches as $match) {
+            yield $match->getClass() => $match->getAnnotation();
         }
     }
 

--- a/tests/App/Bootloader/SitemapBootloader.php
+++ b/tests/App/Bootloader/SitemapBootloader.php
@@ -11,6 +11,7 @@ class SitemapBootloader extends \Spiral\Keeper\Bootloader\SitemapBootloader
     protected function declareSitemap(Sitemap $sitemap): void
     {
         $group = $sitemap->group('custom', 'Custom Group', ['position' => 1.1]);
+        $group->link('root.duplicated', 'Duplicated link');
         $group->link('custom.parent', 'custom parent');
     }
 }

--- a/tests/App/Controller/Sitemap/RootController.php
+++ b/tests/App/Controller/Sitemap/RootController.php
@@ -33,6 +33,14 @@ class RootController
     }
 
     /**
+     * @Link(title="duplicated")
+     * @Action(route="/duplicated")
+     */
+    public function duplicated(): void
+    {
+    }
+
+    /**
      * @Guarded(permission="im-a-child")
      * @Link(title="child", parent="parent")
      * @Action(route="/child", name="root:child")

--- a/tests/Sitemap/AnnotationTest.php
+++ b/tests/Sitemap/AnnotationTest.php
@@ -148,6 +148,14 @@ class AnnotationTest extends TestCase
         $this->assertArrayHasKey('root.bottom', $this->nodes($output, 'rootgroup', 'root.top'));
     }
 
+    public function testDuplicatedElements(): void
+    {
+        $output = $this->getSitemap();
+
+        $this->assertArrayHasKey('root.duplicated', $this->nodes($output, 'custom'));
+        $this->assertArrayNotHasKey('root.duplicated', $this->nodes($output, 'rootgroup'));
+    }
+
     private function getSitemap(bool $onlyVisible = false): array
     {
         $response = $this->get($onlyVisible ? '/default/sitemap/visible' : '/default/sitemap');


### PR DESCRIPTION
All sitemap elements that came from bootloader and annotations are unified by the `type+name` key, so each element can be added only once. With this approach, it's better to declare segments/groups with full options set in the bootloader and use them in a short way (using just the `name` attribute) in the annotations. Also, it will allow declaring only the last (closest to the controller) annotation:
```php
// bootloader
protected function declareSitemap(Sitemap $sitemap): void
{
    $sitemap
    ->group('one', 'SuperGroup')
    ->segment('two', 'SuperSegment')
    ->group('three', 'Group')
    ->group('name', 'FinalGroup');
}

//controller
/**
 * @Group(name="name")
 */
```